### PR TITLE
add "other" Rtype (fixes #6)

### DIFF
--- a/src/statistics/rtype.rs
+++ b/src/statistics/rtype.rs
@@ -88,5 +88,7 @@ super_enum! {
         Doa => (259, "DOA"),
         Ta => (32768, "TA"),
         Dlv => (32769, "DLV"),
+
+        Other => (std::u64::MAX, "other"),
     }
 }


### PR DESCRIPTION
This adds a "other" Rtype.
As this isn't a "real" type, I set it to std::u64::MAX
