### PR TITLE
Fix TLS -> TCP type in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Note that communication via UDS socket or shared memory is not supported for Win
 
 HTTP interface is available at http://0.0.0.0:9167 by default and can be changed via CLI arguments.
 
-### TLS socket
+### TCP socket
 
 First of all, enable `remote-control` option in the [`unbound.conf`](https://nlnetlabs.nl/documentation/unbound/unbound.conf/),
 configure control interface address and TLS if needed.
@@ -54,7 +54,7 @@ configure control interface address and TLS if needed.
 Run the following command to see possible flags and options:
 
 ```bash
-$ unbound-telemetry tls --help
+$ unbound-telemetry tcp --help
 ```
 
 ### Unix domain socket


### PR DESCRIPTION
As you can see `tls` subcommand does not exist, only `tcp`:
```
root@ub:/# ./unbound-telemetry tls --help
error: Found argument 'tls' which wasn't expected, or isn't valid in this context

USAGE:
    unbound-telemetry <SUBCOMMAND>

For more information try --help
root@ub:/# ./unbound-telemetry --help    
unbound-telemetry 0.1.0

USAGE:
    unbound-telemetry <SUBCOMMAND>

FLAGS:
    -h, --help       
            Prints help information

    -V, --version    
            Prints version information


SUBCOMMANDS:
    help    Prints this message or the help of the given subcommand(s)
    shm     Fetch unbound statistics from the shared memory region
    tcp     Fetch unbound statistics from the remote control TCP socket
    uds     Fetch unbound statistics from the remote control Unix socket
```