### PR TITLE
snapcraft: Add basic snap packaging

### DIFF
--- a/.snapcraft.yaml
+++ b/.snapcraft.yaml
@@ -1,0 +1,38 @@
+name: unbound-telemetry
+base: core20
+version: git
+grade: stable
+summary: Unbound DNS resolver metrics exporter for Prometheus
+description: |-
+ Unbound DNS resolver metrics exporter for Prometheus
+
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+  - build-on: armhf
+  - build-on: ppc64el
+  - build-on: s390x
+
+apps:
+  unbound-telemetry:
+    command: daemon.start
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+
+parts:
+  unbound-telemetry:
+    build-packages:
+      - libssl-dev
+      - pkg-config
+    source: .
+    plugin: rust
+    prime:
+      - bin/unbound-telemetry
+
+  wrappers:
+    plugin: dump
+    source: .snapcraft/

--- a/.snapcraft/daemon.start
+++ b/.snapcraft/daemon.start
@@ -1,0 +1,2 @@
+#!/bin/sh -eu
+exec unbound-telemetry tcp -b [::]:9167


### PR DESCRIPTION
This was quickly done to allow for `snap install unbound-telemetry` making deploying it through Ansible on our servers (@nsec) very easy and safe.

For now I'll manually build and refresh it as we see new updates but if you're interested, I can also transfer snap access over to you so you can configure https://snapcraft.io to automatically trigger new builds every time something changes in this repository.

snapd is available on a lot of Linux distributions and there's an Ansible plugin which makes using it to deploy services quite easy.